### PR TITLE
Update farguard url everywhere

### DIFF
--- a/MINIAPP_SETUP.md
+++ b/MINIAPP_SETUP.md
@@ -100,9 +100,9 @@ REACT_APP_ARBISCAN_KEY=your_key
 
 ## 🔗 URLs to Test
 
-- **Main App**: https://fgrevoke.vercel.app
-- **Test Page**: https://fgrevoke.vercel.app/test-miniapp.html  
-- **Manifest**: https://fgrevoke.vercel.app/.well-known/farcaster.json
+- **Main App**: https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard
+- **Test Page**: https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard/test-miniapp.html  
+- **Manifest**: https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard/.well-known/farcaster.json
 
 ## 🎯 Next Steps
 

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
     "build": "craco build",
     "test": "craco test",
     "eject": "react-scripts eject",
-    "verify": "echo 'Testing manifest...' && curl -s https://fgrevoke.vercel.app/.well-known/farcaster.json | head -20",
+    "verify": "echo 'Testing manifest...' && curl -s https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard/.well-known/farcaster.json | head -20",
     "dev": "craco start",
     "preview": "npx serve -s build",
-    "check-manifest": "curl -s https://fgrevoke.vercel.app/.well-known/farcaster.json | jq ."
+    "check-manifest": "curl -s https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard/.well-known/farcaster.json | jq ."
   },
   "eslintConfig": {
     "extends": [

--- a/public/.well-known/farcaster.json
+++ b/public/.well-known/farcaster.json
@@ -9,28 +9,28 @@
     "name": "FarGuard - Token Security Tool",
     "subtitle": "Protect Your Wallet from Risky Approvals",
     "description": "FarGuard helps you find and revoke all your ERC-20/NFT approvals safely. View real token approvals, analyze risks, and revoke dangerous permissions with a single transaction. Works across Ethereum, Base, and Arbitrum.",
-    "iconUrl": "https://fgrevoke.vercel.app/farguard-logo.png",
-    "homeUrl": "https://fgrevoke.vercel.app",
-    "splashImageUrl": "https://fgrevoke.vercel.app/farguard-logo.png",
+    "iconUrl": "https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard/farguard-logo.png",
+    "homeUrl": "https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard",
+    "splashImageUrl": "https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard/farguard-logo.png",
     "splashBackgroundColor": "#1e1b4b",
-    "heroImageUrl": "https://fgrevoke.vercel.app/og-image.png",
+    "heroImageUrl": "https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard/og-image.png",
     "tagline": "Secure your wallet from risky token approvals",
     "screenshotUrls": [
-      "https://fgrevoke.vercel.app/screenshot-1.png",
-      "https://fgrevoke.vercel.app/screenshot-2.png"
+      "https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard/screenshot-1.png",
+      "https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard/screenshot-2.png"
     ],
     "primaryCategory": "finance",
     "tags": ["security", "defi", "wallet", "approvals", "revoke"],
-    "webhookUrl": "https://fgrevoke.vercel.app/api/webhook"
+    "webhookUrl": "https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard/api/webhook"
   },
   "miniapp": {
     "version": "1",
     "name": "FarGuard",
-    "iconUrl": "https://fgrevoke.vercel.app/farguard-logo.png",
-    "homeUrl": "https://fgrevoke.vercel.app",
-    "imageUrl": "https://fgrevoke.vercel.app/og-image.png",
+    "iconUrl": "https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard/farguard-logo.png",
+    "homeUrl": "https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard",
+    "imageUrl": "https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard/og-image.png",
     "buttonTitle": "🛡️ Start Securing",
-    "splashImageUrl": "https://fgrevoke.vercel.app/farguard-logo.png",
+    "splashImageUrl": "https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard/farguard-logo.png",
     "splashBackgroundColor": "#1e1b4b",
     "description": "FarGuard helps you find and revoke all your ERC-20/NFT approvals safely. Protect your wallet from risky token approvals.",
     "requiredChains": [
@@ -43,8 +43,8 @@
     ],
     "categories": ["finance", "utilities", "security"],
     "screenshots": [
-      "https://fgrevoke.vercel.app/screenshot-1.png",
-      "https://fgrevoke.vercel.app/screenshot-2.png"
+      "https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard/screenshot-1.png",
+      "https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard/screenshot-2.png"
     ]
   }
 }

--- a/public/farcaster.json
+++ b/public/farcaster.json
@@ -2,13 +2,13 @@
   "frame": {
     "name": "FarGuard",
     "version": "1",
-    "iconUrl": "https://fgrevoke.vercel.app/farguard-logo.png",
-    "homeUrl": "https://fgrevoke.vercel.app",
-    "imageUrl": "https://fgrevoke.vercel.app/og-image.png",
+    "iconUrl": "https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard/farguard-logo.png",
+    "homeUrl": "https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard",
+    "imageUrl": "https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard/og-image.png",
     "buttonTitle": "Start Securing",
-    "splashImageUrl": "https://fgrevoke.vercel.app/splash.png",
+    "splashImageUrl": "https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard/splash.png",
     "splashBackgroundColor": "#1e1b4b",
-    "webhookUrl": "https://fgrevoke.vercel.app/api/webhook",
+    "webhookUrl": "https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard/api/webhook",
     "subtitle": "Protect Your Wallet from Risky Approvals",
     "description": "FarGuard helps you find and revoke all your ERC-20 and NFT approvals safely. View real token approvals, analyze risks, and revoke dangerous permissions with a single transaction. Works across Ethereum, Base, and Arbitrum.",
     "primaryCategory": "utility",
@@ -19,10 +19,10 @@
       "wallet",
       "sequrity"
     ],
-    "heroImageUrl": "https://fgrevoke.vercel.app/og-image.png",
+    "heroImageUrl": "https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard/og-image.png",
     "ogTitle": "FarGuard",
     "ogDescription": "FarGuard helps you find and revoke all your ERC-20 and NFT approvals safely.",
-    "ogImageUrl": "https://fgrevoke.vercel.app/og-image.png",
+    "ogImageUrl": "https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard/og-image.png",
     "tagline": "stay safe with farguard"
   },
   "accountAssociation": {

--- a/public/index.html
+++ b/public/index.html
@@ -10,23 +10,23 @@
     <meta name="description" content="Manage your token approvals securely on Farcaster. Track and revoke risky contract approvals to protect your wallet." />
     
     <!-- CORRECT Farcaster Miniapp Meta Tags -->
-    <meta name="fc:miniapp" content='{"version":"1","imageUrl":"https://fgrevoke.vercel.app/og-image.png","button":{"title":"🛡️ Start Securing","action":{"type":"launch_frame","name":"FarGuard","url":"https://fgrevoke.vercel.app","splashImageUrl":"https://fgrevoke.vercel.app/farguard-logo.png","splashBackgroundColor":"#1e1b4b"}}}' />
+    <meta name="fc:miniapp" content='{"version":"1","imageUrl":"https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard/og-image.png","button":{"title":"🛡️ Start Securing","action":{"type":"launch_frame","name":"FarGuard","url":"https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard","splashImageUrl":"https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard/farguard-logo.png","splashBackgroundColor":"#1e1b4b"}}}' />
     
     <!-- Backward compatibility frame tag -->
-    <meta name="fc:frame" content='{"version":"1","imageUrl":"https://fgrevoke.vercel.app/og-image.png","button":{"title":"🛡️ Start Securing","action":{"type":"launch_frame","name":"FarGuard","url":"https://fgrevoke.vercel.app","splashImageUrl":"https://fgrevoke.vercel.app/farguard-logo.png","splashBackgroundColor":"#1e1b4b"}}}' />
+    <meta name="fc:frame" content='{"version":"1","imageUrl":"https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard/og-image.png","button":{"title":"🛡️ Start Securing","action":{"type":"launch_frame","name":"FarGuard","url":"https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard","splashImageUrl":"https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard/farguard-logo.png","splashBackgroundColor":"#1e1b4b"}}}' />
     
     <!-- Open Graph Meta Tags -->
     <meta property="og:title" content="FarGuard - Token Approval Manager" />
     <meta property="og:description" content="Manage your token approvals securely on Farcaster. Track and revoke risky contract approvals to protect your wallet." />
-    <meta property="og:image" content="https://fgrevoke.vercel.app/og-image.png" />
-    <meta property="og:url" content="https://fgrevoke.vercel.app" />
+    <meta property="og:image" content="https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard/og-image.png" />
+    <meta property="og:url" content="https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard" />
     <meta property="og:type" content="website" />
     
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="FarGuard - Token Approval Manager" />
     <meta name="twitter:description" content="Manage your token approvals securely on Farcaster" />
-    <meta name="twitter:image" content="https://fgrevoke.vercel.app/og-image.png" />
+    <meta name="twitter:image" content="https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard/og-image.png" />
     
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <script src="https://cdn.tailwindcss.com"></script>

--- a/src/App.js
+++ b/src/App.js
@@ -1177,7 +1177,7 @@ function App() {
   };
 
   const shareCast = () => {
-    const text = encodeURIComponent("Claimed 0.5 USDC for just securing my wallet - try it here: https://fgrevoke.vercel.app");
+            const text = encodeURIComponent("Claimed 0.5 USDC for just securing my wallet - try it here: https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard");
     window.open(`https://warpcast.com/~/compose?text=${text}`, '_blank');
   };
 
@@ -1192,13 +1192,13 @@ function App() {
 🏗️ ${activityStats.dappsUsed} dApps used
 ⛽ ${activityStats.totalGasFees.toFixed(4)} ${chains.find(c => c.value === selectedChain)?.nativeCurrency} in gas fees
 
-Track your journey: https://fgrevoke.vercel.app`
+Track your journey: https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard`
       : `🛡️ Just secured my ${currentChainName} wallet with FarGuard! 
 
 ✅ Reviewed ${approvals.length} token approvals
 🔒 Protecting my assets from risky permissions
 
-Secure yours too: https://fgrevoke.vercel.app`;
+Secure yours too: https://farcaster.xyz/miniapps/42DXu8ldDc8K/farguard`;
 
     try {
       if (sdk?.actions?.composeCast) {


### PR DESCRIPTION
Update all instances of the old Vercel URL to the new Farcaster miniapp URL as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-3a433f94-ba6a-4155-bbdf-f3edad74ac7c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3a433f94-ba6a-4155-bbdf-f3edad74ac7c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>