### PR TITLE
Speed up wallet popup after revoke approval

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2555,6 +2555,24 @@ function App() {
     }
   };
 
+  // Preload revoke utils chunk early to avoid first-click delay
+  useEffect(() => {
+    import('./utils/revoke').catch(() => {});
+  }, []);
+
+  // Warm caches for visible approvals to speed up wallet popup
+  useEffect(() => {
+    if (!address || !approvals || approvals.length === 0) return;
+    import('./utils/revoke')
+      .then(({ preloadForItem }) => {
+        approvals.slice(0, 5).forEach((a) => {
+          if (!a?.contract || !a?.spender) return;
+          preloadForItem({ owner: address, token: a.contract, spender: a.spender }).catch(() => {});
+        });
+      })
+      .catch(() => {});
+  }, [address, approvals]);
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-900 to-indigo-900 text-white font-sans flex flex-col">
       <div className="flex-1 flex flex-col items-center p-4 sm:p-6">

--- a/src/utils/revoke.js
+++ b/src/utils/revoke.js
@@ -167,15 +167,8 @@ async function signTypedDataResilient({ eip1193, signer, owner, domain, types, m
 }
 
 async function sendRawTx({ eip1193, owner, to, data }) {
-  // Estimate gas using public RPC, then send via embedded provider
-  let gasLimitHex;
-  try {
-    const gas = await publicProvider.estimateGas({ from: owner, to, data });
-    const padded = gas.mul(120).div(100); // +20%
-    gasLimitHex = ethers.utils.hexlify(padded);
-  } catch {
-    gasLimitHex = ethers.utils.hexlify(300000); // fallback
-  }
+  // Skip gas estimation to speed up wallet popup; use a conservative fixed limit
+  const gasLimitHex = ethers.utils.hexlify(300000);
   const tx = { from: owner, to, data, chainId: `0x${BASE_CHAIN_ID.toString(16)}`, gas: gasLimitHex, value: "0x0" };
   return await eip1193.request({ method: "eth_sendTransaction", params: [tx] });
 }


### PR DESCRIPTION
Speeds up wallet popup appearance for revoke approvals by preloading logic, warming caches, and skipping pre-transaction gas estimation.

The wallet popup was slow because it waited for a public RPC gas estimation call before displaying. This change removes that blocking call, allowing the wallet UI to appear immediately with a conservative fixed gas limit.

---
<a href="https://cursor.com/background-agent?bcId=bc-cbc60c4a-7374-4171-a350-9a7c8116ee3f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cbc60c4a-7374-4171-a350-9a7c8116ee3f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

