### PR TITLE
Debug relay-metatx claim function errors

### DIFF
--- a/api/prepare-metatx.ts
+++ b/api/prepare-metatx.ts
@@ -28,12 +28,11 @@ export default async function handler(req: IncomingMessage & { method?: string; 
   try {
     // Import everything we need
     console.log("[api/prepare-metatx] Starting imports");
-    const viem = await import("viem");
+    const { parseEther, encodeFunctionData, createWalletClient, http, defineChain } = await import("viem");
+    const { celo } = await import("viem/chains");
     console.log("[api/prepare-metatx] Viem imported");
-    const { parseEther, encodeFunctionData, createWalletClient, http } = viem;
-    const viemAccounts = await import("viem/accounts");
+    const { privateKeyToAccount } = await import("viem/accounts");
     console.log("[api/prepare-metatx] Viem accounts imported");
-    const { privateKeyToAccount } = viemAccounts;
     
     type ChainKey = "celo" | "mon";
     
@@ -109,7 +108,7 @@ export default async function handler(req: IncomingMessage & { method?: string; 
     
     const client = createWalletClient({ 
       account: signerAccount,
-      chain: chain === "celo" ? viem.celo : viem.defineChain({
+      chain: chain === "celo" ? celo : defineChain({
         id: 10143,
         name: "Monad Testnet",
         nativeCurrency: { name: "MON", symbol: "MON", decimals: 18 },

--- a/api/relay-metatx.ts
+++ b/api/relay-metatx.ts
@@ -39,7 +39,7 @@ export default async function handler(req: IncomingMessage & { method?: string; 
     
     const RPCS: Record<ChainKey, string> = {
       celo: process.env.CELO_RPC || "https://forno.celo.org",
-      mon: process.env.MON_RPC || "",
+      mon: process.env.MON_RPC || "https://testnet.monad.network",
     };
     
     const { chain, userAddress, functionSignature, signature } = parsed as {


### PR DESCRIPTION
Fixes Monad RPC configuration and Viem import errors to enable proper MON claim processing and detailed logging.

The `relay-metatx` function was failing due to an incorrect default `MON_RPC` URL and Viem TypeScript errors, preventing connection to the Monad testnet and useful debug output. This PR resolves these issues, allowing for accurate balance checks and revert reason logging.

---
<a href="https://cursor.com/background-agent?bcId=bc-118f4c30-50d2-49e5-9fef-4a02dec70d01">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-118f4c30-50d2-49e5-9fef-4a02dec70d01">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

